### PR TITLE
Update cli.mdoc - syntax fix for user reset-password

### DIFF
--- a/src/content/docs/usage/cli.mdoc
+++ b/src/content/docs/usage/cli.mdoc
@@ -195,7 +195,7 @@ Reset a users password, either through mailing them a reset link or directly.
 Usage:
 
 ```sh
-vikunja user reset-password [flags]
+vikunja user reset-password [user id] [flags]
 ```
 
 Flags:


### PR DESCRIPTION
There is a slight typo / missing information in the usage example related to password reset in the documentation related to [Command line interface](https://vikunja.io/docs/cli/#user-reset-password).

Instead of 
```shell
vikunja user reset-password [flags]
```

there should be 

```shell
vikunja user reset-password [user id] [flags]
```