### PR TITLE
Switch setup docs to Postgres

### DIFF
--- a/src/content/docs/setup/docker-start-to-finish.mdoc
+++ b/src/content/docs/setup/docker-start-to-finish.mdoc
@@ -29,7 +29,7 @@ services:
             VIKUNJA_SERVICE_PUBLICURL: http://<the public url where Vikunja is reachable>
             VIKUNJA_DATABASE_HOST: db
             VIKUNJA_DATABASE_PASSWORD: changeme
-            VIKUNJA_DATABASE_TYPE: mysql
+            VIKUNJA_DATABASE_TYPE: postgres
             VIKUNJA_DATABASE_USER: vikunja
             VIKUNJA_DATABASE_DATABASE: vikunja
             VIKUNJA_SERVICE_JWTSECRET: <a super secure random secret>
@@ -42,18 +42,18 @@ services:
                 condition: service_healthy
         restart: unless-stopped
     db:
-        image: mariadb:10
-        command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+        image: postgres:17
+        
         environment:
-            MYSQL_ROOT_PASSWORD: supersecret
-            MYSQL_USER: vikunja
-            MYSQL_PASSWORD: changeme
-            MYSQL_DATABASE: vikunja
+            POSTGRES_PASSWORD: changeme
+            POSTGRES_USER: vikunja
+            
+            
         volumes:
-            - ./db:/var/lib/mysql
+            - ./db:/var/lib/postgresql/data
         restart: unless-stopped
         healthcheck:
-            test: ["CMD-SHELL", "mysqladmin ping -h localhost -u $$MYSQL_USER --password=$$MYSQL_PASSWORD"]
+            test: ["CMD-SHELL", "pg_isready -h localhost -U $$POSTGRES_USER"]
             interval: 2s
 			start_period: 30s
 ```
@@ -61,7 +61,7 @@ services:
 This defines two services, each with their own container:
 
 * A Vikunja service which runs the Vikunja api and hosts its frontend.
-* A database container which will store all projects, tasks, etc. We're using mariadb here, but you're free to use mysql or postgres if you want.
+* A database container which will store all projects, tasks, etc. We're using postgres here, but you're free to use mysql or mariadb if you want.
 
 If you already have a proxy on your host, you may want to check out the [reverse proxy examples](/docs/reverse-proxy) to use that.
 By default, Vikunja will be exposed on port 3456 on the host.
@@ -112,18 +112,17 @@ Indicated by an error message like this one from the api container:
 2020-05-23T15:37:59.974435725Z: CRITICAL	▶ migration/Migrate 002 Migration failed: dial tcp 172.19.0.2:3306: connect: connection refused
 ```
 
-Especially when using mysql, this can happen on first start, because the mysql database container will take a few seconds to start.
+Especially when using postgres, this can happen on first start, because the postgres database container will take a few seconds to start.
 Vikunja does not know the container is not ready, therefore it will just try to connect to the db, fail since it is not ready and exit.
 
 If you're using the docker compose example from above, you may notice the `restart: unless-stopped` option at the api service.
 This tells docker to restart the api container if it exits, unless you explicitly stop it.
 Therefore, it should "magically fix itself" by automatically restarting the container.
 
-After a few seconds (or minutes) you should see a log message like this one from the mariadb container:
+After a few seconds (or minutes) you should see a log message like this one from the postgres container:
 
 ```
-2020-05-24 11:42:15 0 [Note] mysqld: ready for connections.
-Version: '10.4.12-MariaDB-1:10.4.12+maria~bionic'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
+2024-01-01 00:00:00.000 UTC [1] LOG:  database system is ready to accept connections
 ```
 
 The next restart of Vikunja should be successful.

--- a/src/content/docs/setup/docker-start-to-finish.mdoc
+++ b/src/content/docs/setup/docker-start-to-finish.mdoc
@@ -43,11 +43,9 @@ services:
         restart: unless-stopped
     db:
         image: postgres:17
-        
         environment:
             POSTGRES_PASSWORD: changeme
             POSTGRES_USER: vikunja
-            
             
         volumes:
             - ./db:/var/lib/postgresql/data

--- a/src/content/docs/setup/full-docker-example.mdoc
+++ b/src/content/docs/setup/full-docker-example.mdoc
@@ -6,7 +6,7 @@ description: >-
   and proxy configurations. Includes examples popular reverse proxies.
 ---
 
-This docker compose configuration will run Vikunja with a mariadb database.
+This docker compose configuration will run Vikunja with a postgres database.
 It uses a proxy configuration to make it available under a domain.
 
 For all available configuration options, see [configuration](/docs/config-options).
@@ -14,9 +14,9 @@ For all available configuration options, see [configuration](/docs/config-option
 After registering all your users, you might also want to [disable the user registration](/docs/config-options#1-service-enableregistration).
 
 {% callout type="warning" %}
-If you intend to run Vikunja with mysql and/or to use non-latin characters
+If you intend to run Vikunja with MySQL or MariaDB and/or to use non-latin characters
 [make sure your db is utf-8 compatible](/docs/utf-8-settings).
-All examples on this page already reflect this and do not require additional work.
+All examples on this page use postgres and do not require additional work.
 {% /callout %}
 
 ## File permissions
@@ -36,30 +36,34 @@ You'll need to do this before running any of the examples on this page.
 
 Vikunja will not try to acquire ownership of the files folder, as that would mean it had to run as root.
 
-## PostgreSQL
+## MySQL / MariaDB
 
-Vikunja supports postgres, mysql and sqlite as a database backend. The examples on this page use mysql with a mariadb container.
-To use postgres as a database backend, change the `db` section of the examples to this:
+Vikunja supports postgres, mysql and sqlite as a database backend. The examples on this page use postgres with a postgres container.
+To use MySQL or MariaDB as a database backend, change the `db` section of the examples to this:
 
 ```yaml
 db:
-  image: postgres:17
+  image: mariadb:10
+  command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
   environment:
-    POSTGRES_PASSWORD: changeme
-    POSTGRES_USER: vikunja
+    MYSQL_ROOT_PASSWORD: supersecret
+    MYSQL_USER: vikunja
+    MYSQL_PASSWORD: changeme
+    MYSQL_DATABASE: vikunja
   volumes:
-    - ./db:/var/lib/postgresql/data
+    - ./db:/var/lib/mysql
   restart: unless-stopped
   healthcheck:
-    test: ["CMD-SHELL", "pg_isready -h localhost -U $$POSTGRES_USER"]
+    test: ["CMD-SHELL", "mysqladmin ping -h localhost -u $$MYSQL_USER --password=$$MYSQL_PASSWORD"]
     interval: 2s
+    start_period: 30s
 ```
 
-You'll also need to change the `VIKUNJA_DATABASE_TYPE` to `postgres` on the vikunja container declaration.
+You'll also need to change the `VIKUNJA_DATABASE_TYPE` to `mysql` on the vikunja container declaration.
 
 ## Sqlite
 
-Vikunja supports postgres, mysql and sqlite as a database backend. The examples on this page use mysql with a mariadb container.
+Vikunja supports postgres, mysql and sqlite as a database backend. The examples on this page use postgres with a postgres container.
 To use sqlite as a database backend, change the `vikunja` section of the examples to this:
 
 ```yaml
@@ -120,7 +124,7 @@ services:
       VIKUNJA_SERVICE_PUBLICURL: http://<the public ip or host where Vikunja is reachable>
       VIKUNJA_DATABASE_HOST: db
       VIKUNJA_DATABASE_PASSWORD: changeme
-      VIKUNJA_DATABASE_TYPE: mysql
+      VIKUNJA_DATABASE_TYPE: postgres
       VIKUNJA_DATABASE_USER: vikunja
       VIKUNJA_DATABASE_DATABASE: vikunja
       VIKUNJA_SERVICE_JWTSECRET: <a super secure random secret>
@@ -133,18 +137,15 @@ services:
         condition: service_healthy
     restart: unless-stopped
   db:
-    image: mariadb:10
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    image: postgres:17
     environment:
-      MYSQL_ROOT_PASSWORD: supersecret
-      MYSQL_USER: vikunja
-      MYSQL_PASSWORD: changeme
-      MYSQL_DATABASE: vikunja
+      POSTGRES_PASSWORD: changeme
+      POSTGRES_USER: vikunja
     volumes:
-      - ./db:/var/lib/mysql
+      - ./db:/var/lib/postgresql/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u $$MYSQL_USER --password=$$MYSQL_PASSWORD"]
+      test: ["CMD-SHELL", "pg_isready -h localhost -U $$POSTGRES_USER"]
       interval: 2s
       start_period: 30s
 ```
@@ -172,7 +173,7 @@ services:
       VIKUNJA_SERVICE_PUBLICURL: http://<the public url where Vikunja is reachable>
       VIKUNJA_DATABASE_HOST: db
       VIKUNJA_DATABASE_PASSWORD: changeme
-      VIKUNJA_DATABASE_TYPE: mysql
+      VIKUNJA_DATABASE_TYPE: postgres
       VIKUNJA_DATABASE_USER: vikunja
       VIKUNJA_DATABASE_DATABASE: vikunja
       VIKUNJA_SERVICE_JWTSECRET: <a super secure random secret>
@@ -192,18 +193,16 @@ services:
       - "traefik.http.routers.vikunja.entrypoints=https"
       - "traefik.http.routers.vikunja.tls.certResolver=acme"
   db:
-    image: mariadb:10
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    image: postgres:17
+    
     environment:
-      MYSQL_ROOT_PASSWORD: supersupersecret 
-      MYSQL_USER: vikunja
-      MYSQL_PASSWORD: changeme
-      MYSQL_DATABASE: vikunja
+      POSTGRES_PASSWORD: changeme 
+      POSTGRES_USER: vikunja
     volumes:
-      - ./db:/var/lib/mysql
+      - ./db:/var/lib/postgresql/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u $$MYSQL_USER --password=$$MYSQL_PASSWORD"]
+      test: ["CMD-SHELL", "pg_isready -h localhost -U $$POSTGRES_USER"]
       interval: 2s
       start_period: 30s
 
@@ -240,7 +239,7 @@ services:
       VIKUNJA_SERVICE_PUBLICURL: http://<the public url where Vikunja is reachable>
       VIKUNJA_DATABASE_HOST: db
       VIKUNJA_DATABASE_PASSWORD: changeme
-      VIKUNJA_DATABASE_TYPE: mysql
+      VIKUNJA_DATABASE_TYPE: postgres
       VIKUNJA_DATABASE_USER: vikunja
       VIKUNJA_DATABASE_DATABASE: vikunja
       VIKUNJA_SERVICE_JWTSECRET: <a super secure random secret>
@@ -253,18 +252,16 @@ services:
         condition: service_healthy
     restart: unless-stopped
   db:
-    image: mariadb:10
+    image: postgres:17
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     environment:
-      MYSQL_ROOT_PASSWORD: supersecret
-      MYSQL_USER: vikunja
-      MYSQL_PASSWORD: changeme
-      MYSQL_DATABASE: vikunja
+      POSTGRES_PASSWORD: changeme
+      POSTGRES_USER: vikunja
     volumes:
-      - ./db:/var/lib/mysql
+      - ./db:/var/lib/postgresql/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u $$MYSQL_USER --password=$$MYSQL_PASSWORD"]
+      test: ["CMD-SHELL", "pg_isready -h localhost -U $$POSTGRES_USER"]
       interval: 2s
       start_period: 30s
   caddy:
@@ -286,12 +283,12 @@ you need to prepare a proxy rule the Vikunja Service.
 
 ![Synology Proxy Settings](../../../assets/images/docs/synology-proxy-1.png)
 
-You should also add 2 empty folders for MariaDB and Vikunja inside Synology's
+You should also add 2 empty folders for PostgreSQL and Vikunja inside Synology's
 docker main folders:
 
 * Docker
   * vikunja
-  * mariadb
+  * postgres
 
 Synology has its own GUI for managing Docker containers, but it's easier via docker compose.
 

--- a/src/content/docs/setup/full-docker-example.mdoc
+++ b/src/content/docs/setup/full-docker-example.mdoc
@@ -194,7 +194,6 @@ services:
       - "traefik.http.routers.vikunja.tls.certResolver=acme"
   db:
     image: postgres:17
-    
     environment:
       POSTGRES_PASSWORD: changeme 
       POSTGRES_USER: vikunja

--- a/src/content/docs/setup/install.mdoc
+++ b/src/content/docs/setup/install.mdoc
@@ -18,7 +18,7 @@ You can also:
 * Use the mobile app only, but as of right now it only supports the very basic features of Vikunja
 
 {% callout type="warning" %}
-If you intend to run Vikunja with mysql and/or to use non-latin
+If you intend to run Vikunja with MySQL or MariaDB and/or to use non-latin
 characters [make sure your db is utf-8 compatible](/docs/utf-8-settings).
 {% /callout %}
 
@@ -149,7 +149,7 @@ This will expose Vikunja on port `3456` on the host running the container and us
 You can use Docker's [`--user`](https://docs.docker.com/engine/reference/run/#user) flag to change that.
 Make sure the new user has required permissions on the `db` and `files` folder.
 
-Check out the [docker examples](/docs/full-docker-example) for more advanced configuration using mysql / postgres and a
+Check out the [docker examples](/docs/full-docker-example) for more advanced configuration using postgres or mysql and a
 reverse proxy.
 
 ### Using a configuration file with docker

--- a/src/content/docs/setup/reverse-proxies.mdoc
+++ b/src/content/docs/setup/reverse-proxies.mdoc
@@ -49,7 +49,7 @@ example:
       VIKUNJA_SERVICE_PUBLICURL: https://vikunja.example.com/ # change vikunja.example.com to your desired domain/subdomain.
       VIKUNJA_DATABASE_HOST: db
       VIKUNJA_DATABASE_PASSWORD: secret
-      VIKUNJA_DATABASE_TYPE: mysql
+      VIKUNJA_DATABASE_TYPE: postgres
       VIKUNJA_DATABASE_USER: vikunja
       VIKUNJA_DATABASE_DATABASE: vikunja
       VIKUNJA_SERVICE_JWTSECRET: <your-random-secret>


### PR DESCRIPTION
## Summary
- update full docker example to use Postgres
- rewrite docker start-to-finish guide for Postgres
- tweak install instructions
- adjust reverse proxy example
- fix comment mistakes in docs

## Testing
- `pnpm run lint` *(fails: Parameter implicit any, TURNSTILE_SECRET not exported, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68480ac3fe5c8322a77212dc8bf754a0