### PR TITLE
fix: mobile padding on some content pages

### DIFF
--- a/src/layouts/Content.astro
+++ b/src/layouts/Content.astro
@@ -17,7 +17,7 @@ const description = Astro.props?.frontmatter?.description || Astro.props.descrip
 ---
 
 <Layout title={title} type="text" image={image} description={description}>
-    <main class="mx-auto max-w-(--breakpoint-lg)">
+    <main class="mx-auto max-w-(--breakpoint-lg) px-4 md:px-0">
         <Prose>
             <slot/>
         </Prose>


### PR DESCRIPTION
## Summary
- ensure all content pages have mobile padding by default

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685c68b2f0a48322a39f20dd45b86598