### PR TITLE
Update openid-examples.mdoc to fix wrong doc

### DIFF
--- a/src/content/docs/setup/openid-examples.mdoc
+++ b/src/content/docs/setup/openid-examples.mdoc
@@ -107,7 +107,7 @@ auth:
     redirecturl: "https://vikunja.mydomain.com/auth/openid/"
     providers:
       - name: authentik
-        authurl: "https://authentik.mydomain.com/application/o/vikunja"
+        authurl: "https://authentik.mydomain.com/application/o/vikunja/"
         logouturl: "https://authentik.mydomain.com/application/o/vikunja/end-session/"
         clientid: "" # copy from Authetik
         clientsecret: "" # copy from Authentik


### PR DESCRIPTION
Before:

```bash
anduin@proart:/swarm-vol/vikunja$ sudo docker logs -f f8dff
2025-07-17T13:18:36Z: INFO	▶ 001 Using config file: /app/vikunja/config.yml
2025-07-17T13:18:36Z: INFO	▶ 002 Running migrations…
2025-07-17T13:18:36Z: INFO	▶ 06a Ran all migrations successfully.
2025-07-17T13:18:36Z: INFO	▶ 06b Mailer is disabled, not sending reminders per mail
2025-07-17T13:18:36Z: INFO	▶ 06c Mailer is disabled, not sending overdue per mail
2025-07-17T13:18:36Z: INFO	▶ 06d Vikunja version v0.24.6
⇨ http server started on [::]:3456
2025-07-17T13:18:36Z: WEB 	▶ 192.168.1.133  GET 200 /auth/openid/ 3.961635ms - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:18:36Z: WEB 	▶ 192.168.1.133  GET 304 /assets/index-BdIWn3Ve.js 5.43033ms - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:18:36Z: WEB 	▶ 192.168.1.133  GET 304 /assets/index-i4VRmjeA.css 5.362458ms - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:18:37Z: WEB 	▶ 192.168.1.133  GET 304 /manifest.webmanifest 85.367µs - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:18:37Z: ERROR	▶ 0e9 Error while getting openid provider aiursoft: oidc: issuer did not match the issuer returned by provider, expected "https://auth.mistery.cn/application/o/vikunja" got "https://auth.mistery.cn/application/o/vikunja/"
```

After I added it:

```bash
anduin@proart:/swarm-vol/vikunja$ sudo docker logs -f 8ddc96
2025-07-17T13:24:19Z: INFO	▶ 001 Using config file: /app/vikunja/config.yml
2025-07-17T13:24:19Z: INFO	▶ 002 Running migrations…
2025-07-17T13:24:19Z: INFO	▶ 06a Ran all migrations successfully.
2025-07-17T13:24:19Z: INFO	▶ 06b Mailer is disabled, not sending reminders per mail
2025-07-17T13:24:19Z: INFO	▶ 06c Mailer is disabled, not sending overdue per mail
2025-07-17T13:24:19Z: INFO	▶ 06d Vikunja version v0.24.6
⇨ http server started on [::]:3456
2025-07-17T13:24:45Z: WEB 	▶ 192.168.1.133  GET 200 /login 1.917137ms - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:24:45Z: WEB 	▶ 192.168.1.133  GET 200 /assets/index-i4VRmjeA.css 5.747493ms - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:24:45Z: WEB 	▶ 192.168.1.133  GET 200 /assets/index-BdIWn3Ve.js 21.193537ms - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:24:45Z: WEB 	▶ 192.168.1.133  GET 200 /assets/OpenSans_wght__54a65da5-BSoKZk7G.woff2 725.896µs - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:24:45Z: WEB 	▶ 192.168.1.133  GET 200 /assets/llama-nightscape-mKZQPxXM.jpg 1.924533ms - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:24:45Z: WEB 	▶ 192.168.1.133  GET 200 /favicon.ico 578.246µs - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:24:45Z: WEB 	▶ 192.168.1.133  GET 200 /manifest.webmanifest 366.648µs - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:24:45Z: WEB 	▶ 192.168.1.133  GET 200 /images/icons/android-chrome-192x192.png 961.003µs - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:24:45Z: WEB 	▶ 192.168.1.133  GET 200 /assets/index-BdIWn3Ve.js.map 134.743091ms - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:24:46Z: WEB 	▶ 192.168.1.133  GET 200 /api/v1/info 203.434862ms - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:24:46Z: WEB 	▶ 192.168.1.133  GET 200 /assets/llama-SxB1d0EY.svg?url 163.127µs - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
2025-07-17T13:24:46Z: WEB 	▶ 192.168.1.133  GET 200 /assets/Quicksand_wght__87bdcc7f-CH4TLDJK.woff2 614.889µs - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36

```

Seems the doc is misleading.