### PR TITLE
docs: remove caddy handle

### DIFF
--- a/src/content/docs/setup/reverse-proxies.mdoc
+++ b/src/content/docs/setup/reverse-proxies.mdoc
@@ -139,8 +139,6 @@ Adjust the following Caddyfile to get Vikunja up and running:
 
 ```conf
 vikunja.example.com {
-	handle /* {
-		reverse_proxy 127.0.0.1:3456
-	}
+    reverse_proxy 127.0.0.1:3456
 }
 ```


### PR DESCRIPTION
For caddy you don't require a handle section if it is the only reverse_proxy for all path on the domain.