### PR TITLE
docs: tweak docs for reverse proxy with Apache

### DIFF
--- a/src/content/docs/setup/reverse-proxies.mdoc
+++ b/src/content/docs/setup/reverse-proxies.mdoc
@@ -116,15 +116,14 @@ Your Vikunja service should now work and your HTTPS frontend should be able to r
 
 ## Apache
 
-Put the following config in `cat /etc/apache2/sites-available/vikunja.conf`:
+Put the following config in `/etc/apache2/sites-available/vikunja.conf`:
 
 ```aconf
 <VirtualHost *:80>
     ServerName localhost
-   
+
     <Proxy *>
-      Order Deny,Allow
-      Allow from all
+      Require all granted
     </Proxy>
     ProxyPass / http://localhost:3456/
     ProxyPassReverse / http://localhost:3456/


### PR DESCRIPTION
The old syntax with "Allow from all" doesn't work anymore for Apache 2.4 (unless one uses the module "mod_access_compat"). The new syntax to give unconditional access is "Require all grantes".

The other tweaks (removal of "cat" and the leading spaces) are unrelated, but look like small improvements to me.