### PR TITLE
docs: add mDone to External Integrations

### DIFF
--- a/src/content/docs/integrations/integrations.mdx
+++ b/src/content/docs/integrations/integrations.mdx
@@ -9,7 +9,7 @@ description: >-
 This page showcases community-maintained tools and integrations that work with Vikunja. 
 These tools extend Vikunja's functionality and can help you integrate it into your existing workflows.
 
-Do you know of other tools or integrations that work well with Vikunja? Feel free to [contribute to this page](https://github.com/go-vikunja/website/blob/main/src/content/docs/usage/integrations.mdoc) or let us know about them! 
+Do you know of other tools or integrations that work well with Vikunja? Feel free to [contribute to this page](https://github.com/go-vikunja/website/blob/main/src/content/docs/integrations/integrations.mdx) or let us know about them! 
 
 ## Vja - Vikunja Client
 
@@ -40,3 +40,9 @@ Visit the [Vikunja Home Assistant Integration GitHub repository](https://github.
 [Cria](https://github.com/frigidplatypus/cria) is a fast, keyboard-driven terminal user interface (TUI) for managing tasks with the Vikunja API. It features quick actions for rapid task modification, customizable column layouts, and powerful filtering capabilities. The tool supports flexible configuration through YAML files and includes unique features like automatic project setting through filter descriptions.
 
 Visit the [Cria GitHub repository](https://github.com/frigidplatypus/cria) to learn more.
+
+## mDone
+
+[mDone](https://marco308.github.io/mdone/) is a native iOS and macOS app for Vikunja. It connects directly to your own Vikunja server over the REST API with no middleman, no account in between, and no analytics, tracking, or third-party SDKs. On top of standard task management it adds focus sessions and Home/Lock Screen widgets to keep your current task front of mind.
+
+Visit the [mDone website](https://marco308.github.io/mdone/) to learn more.


### PR DESCRIPTION
Adds [mDone](https://marco308.github.io/mdone/), a native iOS and macOS app for Vikunja, to the External Integrations page.

Following up on @kolaente's offer in the [community thread](https://community.vikunja.io/t/mdone-a-native-ios-and-macos-app-for-vikunja/4548) to take a PR mentioning it in the docs. mDone talks only to your own server over the REST API (no middleman, no account in between, no tracking) and adds focus sessions and Home/Lock Screen widgets on top of Vikunja.

While here, this also fixes the stale "contribute to this page" link at the top of the page, which pointed at `src/content/docs/usage/integrations.mdoc` (a non-existent path) instead of the actual file `src/content/docs/integrations/integrations.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)