### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/src/content/docs/setup/install.mdx
+++ b/src/content/docs/setup/install.mdx
@@ -54,6 +54,12 @@ And after you installed Vikunja, you may want to check out these other resources
 
 <CloudHostingAffiliate />
 
+## Managed hosting
+
+If you'd rather not run and maintain Vikunja yourself, [Zenith](https://zenith.hosting/host/vikunja) offers one-click managed hosting for Vikunja and handles updates, backups and the server for you.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/vikunja)
+
 ## Install from binary
 
 Download a copy of Vikunja from the [download page](https://dl.vikunja.io/vikunja/) for your architecture.


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Vikunja to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the install docs (a new "Managed hosting" section on the Installing page, right after the existing cloud/server hosting recommendations). it links to https://zenith.hosting/host/vikunja.

thanks @kolaente for pointing me here. we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

disclosure: this PR was prepared with AI assistance.