### PR TITLE
feat: prefetch pages on link hover

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,9 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
 	site: 'https://vikunja.io',
 	output: 'static',
+	prefetch: {
+		prefetchAll: true,
+	},
 	vite: {
 		plugins: [
 			tailwindcss(),

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -24,7 +24,8 @@ const entries = await getChangelogEntries()
         <div class="flex items-center justify-between mb-6">
             <h1 class="text-4xl font-display font-bold">Changelog</h1>
             <a 
-                href="/changelog/rss.xml" 
+                href="/changelog/rss.xml"
+                data-astro-prefetch="false"
                 class="inline-flex items-center gap-2 rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 transition"
                 title="Subscribe to RSS feed"
             >


### PR DESCRIPTION
Enable Astro's built-in prefetch for all internal links so page
navigations feel instant. The RSS feed link opts out since
prefetching it on hover has no benefit.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A6ai6hvw5AB32o6pDstmMz