### PR TITLE
docs: document client IP extraction behind a reverse proxy

### DIFF
--- a/src/content/docs/setup/fail2ban.mdx
+++ b/src/content/docs/setup/fail2ban.mdx
@@ -4,12 +4,17 @@ slug: fail2ban
 description: >-
   This guide explains how to configure Fail2Ban to protect your Vikunja instance from repeated failed login attempts.
 ---
+import Callout from '../../../components/Callout.astro';
 
 To protect your Vikunja instance from brute-force and abusive requests, you can use [Fail2Ban](https://github.com/fail2ban/fail2ban), which monitors logs and blocks IPs at the network level after repeated failed logins.
 
 Use the [ratelimit options](/docs/config-options/#0--ratelimit) to limit request frequency across endpoints, and Fail2Ban when you want to ban clients entirely.
 
 Both mechanisms can be used together to provide layered protection against abuse and unauthorized access attempts.
+
+<Callout type="warning">
+**NOTE:** If Vikunja runs behind a reverse proxy, configure [client IP addresses](/docs/reverse-proxy#client-ip-addresses) first. Otherwise `remote_ip` in the HTTP log is the proxy's address rather than the client's, and this jail bans the proxy after `maxretry` failed logins, which locks out every user.
+</Callout>
 
 ## Configure Vikunja
 

--- a/src/content/docs/setup/reverse-proxies.mdx
+++ b/src/content/docs/setup/reverse-proxies.mdx
@@ -10,6 +10,8 @@ import Callout from '../../../components/Callout.astro';
 These examples assume you have an instance of Vikunja running on your server listening on port `3456`.
 If you've changed this setting, you need to update the server configurations accordingly.
 
+Whichever proxy you use, see [Client IP addresses](#client-ip-addresses) below so that Vikunja logs and rate limits the real client instead of the proxy.
+
 ## NGINX
 
 You may need to adjust `server_name` and `root` accordingly.
@@ -142,3 +144,30 @@ vikunja.example.com {
     reverse_proxy 127.0.0.1:3456
 }
 ```
+
+## Client IP addresses
+
+By default, Vikunja uses the TCP remote address of the incoming connection to identify a client. Behind a reverse proxy that address is the proxy itself, so every request is logged and rate limited as if it came from the proxy and the real client address is discarded.
+
+To make Vikunja read the client address from the `X-Forwarded-For` header your proxy already sets, set the extraction method and list the addresses your proxy connects from:
+
+```yaml
+service:
+    ipextractionmethod: xff
+    trustedproxies: 127.0.0.1/32,::1/128
+```
+
+The same via environment variables:
+
+```sh
+export VIKUNJA_SERVICE_IPEXTRACTIONMETHOD=xff
+export VIKUNJA_SERVICE_TRUSTEDPROXIES=127.0.0.1/32,::1/128
+```
+
+`X-Forwarded-For` is only trusted when the request arrives from an address listed in `trustedproxies`, so a client that reaches Vikunja directly cannot forge it. See the [service options](/docs/config-options/#0--service) for the full description, including the `realip` method.
+
+<Callout type="warning">
+**NOTE:** Keep `trustedproxies` as narrow as possible. If Vikunja's port is reachable from anywhere other than the proxy, a broad range such as `10.0.0.0/8` lets any client on that network send an `X-Forwarded-For` header and appear as an address of their choosing. List only the addresses your proxy connects from.
+</Callout>
+
+This affects everything that acts on the client address, including the [ratelimit](/docs/config-options/#0--ratelimit) options and [Fail2Ban](/docs/fail2ban).


### PR DESCRIPTION
## What

Adds a **Client IP addresses** section to the reverse proxy guide covering `service.ipextractionmethod` and `service.trustedproxies`, and cross-references it from the Fail2Ban guide.

## Why

`service.ipextractionmethod` defaults to `direct`, which uses the TCP remote address and ignores forwarding headers. Behind a reverse proxy that address is the proxy itself, so Vikunja logs and rate limits every request as if it came from the proxy and the real client address is discarded. The reverse proxy guide walks through NGINX, NPM, Apache and Caddy without mentioning this, so following it end to end leaves you with an instance that cannot tell clients apart. The options are documented in the generated config reference, but nothing links the two pages, and the config reference is not where you look while setting up a proxy.

I hit this on a stock Caddy setup. Every request logged as the proxy:

```
level=INFO component=http remote_ip=10.0.0.1 method=GET uri="/?cb=18732" status=200
level=INFO component=http remote_ip=10.0.0.1 method=GET uri="/?cb=9543"  status=200
```

The first request came from a public address via a CDN, the second from a LAN address. After setting `ipextractionmethod: xff` and `trustedproxies` to the proxy address, the same two requests:

```
level=INFO component=http remote_ip=203.0.113.10 method=GET uri="/?cb=32045" status=200
level=INFO component=http remote_ip=10.0.0.50    method=GET uri="/?cb=2790"  status=200
```

## Fail2Ban

The Fail2Ban guide is affected more sharply, which is why I touched it too. Its filter matches on `remote_ip`:

```conf
failregex = ^.*\bmsg="POST\s+/api/v\d+/login[^"]*".*\bstatus=(?:400|403|412)\b.*\bremote_ip=<HOST>\b.*$
```

With the default extraction method behind a proxy, `remote_ip` is the proxy's address for every request, so three failed logins from anyone bans the reverse proxy and locks out every user. The added callout points at the new section.

## Note on the security warning

The config reference gives `127.0.0.1/32,::1/128,10.0.0.0/8,172.16.0.0/12` as an example value. Copied literally into a Docker setup where the port is published on the host, that trusts an entire private range, and any client able to reach Vikunja directly can set `X-Forwarded-For` and appear as an address of their choosing. The new section keeps the example minimal and adds a callout about scoping it to the proxy. Happy to adjust the wording if you would rather it read differently.

## Testing

`pnpm run build` passes. Verified in the built output that the `client-ip-addresses` anchor is generated, the page table of contents picks it up, and the cross-link from the Fail2Ban page resolves.

