### PR TITLE
docs: fix grammar and spelling typos in privacy policy and changelog

### DIFF
--- a/src/content/changelog/release-2.2.0.mdx
+++ b/src/content/changelog/release-2.2.0.mdx
@@ -12,7 +12,7 @@ description: >-
 It's been three weeks since the last release and there's a bunch to cover.
 This release contains 237 commits with ten security fixes, a bunch of new features, and a long list of bug fixes and improvements.
 
-Updating is highly reccomended!
+Updating is highly recommended!
 
 ## Security
 

--- a/src/content/changelog/release-2.5.0.mdx
+++ b/src/content/changelog/release-2.5.0.mdx
@@ -27,7 +27,7 @@ If you're building against the API, the bulk endpoint is worth using for anythin
 
 ## Fixes and improvements
 
-105 of the commits in this release are fixes. That's not exaclty 105 separate bugs, plenty of them are several commits chipping away at the same thing.
+105 of the commits in this release are fixes. That's not exactly 105 separate bugs, plenty of them are several commits chipping away at the same thing.
 
 The ones most likely to affect you:
 

--- a/src/pages/privacy.md
+++ b/src/pages/privacy.md
@@ -7,7 +7,7 @@ description: Learn about vikunja.io's privacy policy, GDPR compliance, data prot
 # Privacy Policy for vikunja.io
 
 At vikunja.io, one of our main priorities is the privacy of our visitors. 
-This Privacy Policy document contains types of information that is collected and recorded by vikunja.io and how we use it.
+This Privacy Policy document contains types of information that are collected and recorded by vikunja.io and how we use it.
 
 If you have additional questions or require more information about our Privacy Policy, do not hesitate to contact us through email at [gdpr@vikunja.io](mailto:gdpr@vikunja.io).
 
@@ -15,7 +15,7 @@ If you have additional questions or require more information about our Privacy P
 
 We are a Data Controller of your information.
 
-vikunja.io legal basis for collecting and using the personal information described in this Privacy Policy depends on the Personal Information we collect 
+vikunja.io's legal basis for collecting and using the personal information described in this Privacy Policy depends on the Personal Information we collect 
 and the specific context in which we collect the information:
 
 *   vikunja.io needs to perform a contract with you
@@ -43,8 +43,8 @@ In certain circumstances, you have the following data protection rights:
 ## Log Files
 
 vikunja.io follows a standard procedure of using log files. These files log visitors when they visit websites. 
-All hosting companies do this and a part of hosting services' analytics. The information collected by log files 
-include internet protocol (IP) addresses, browser type, Internet Service Provider (ISP), date and time stamp, referring/exit pages, 
+All hosting companies do this and are a part of hosting services' analytics. The information collected by log files 
+includes internet protocol (IP) addresses, browser type, Internet Service Provider (ISP), date and time stamp, referring/exit pages, 
 and possibly the number of clicks. These are not linked to any information that is personally identifiable. 
 The purpose of the information is for administering the site, preventing abuse and gathering demographic information.
 


### PR DESCRIPTION
## Summary

Six text-only corrections across three hand-written source files. **All changes are non-substantive**: no meaning, scope, legal effect, named entity, or URL is altered — only subject-verb agreement, a missing possessive, a missing verb, and two misspellings.

`src/pages/privacy.md` is a legal document, so the edits there were deliberately kept to the narrowest grammatical form of each fix. No clause was reworded, no term was redefined, and the two privacy-policy generator links (`gdprprivacypolicy.net`, `privacypolicytemplate.net`) are untouched and still resolve.

### `src/pages/privacy.md`

- `contains types of information that is collected` -> `that are collected`
  Subject-verb agreement: the subject is the plural *types*.
- `vikunja.io legal basis for collecting` -> `vikunja.io's legal basis for collecting`
  Missing possessive. The file already uses `vikunja.io's` twice (front-matter description, and the legitimate-interests bullet), so this matches the file's own usage.
- `All hosting companies do this and a part of hosting services' analytics.` -> `... and are a part of ...`
  The clause had no verb.
- `The information collected by log files include internet protocol (IP) addresses` -> `includes`
  Subject-verb agreement: the subject is the singular *The information*.

### `src/content/changelog/release-2.5.0.mdx`

- `exaclty` -> `exactly`

### `src/content/changelog/release-2.2.0.mdx`

- `reccomended` -> `recommended`

---

The two changelog fixes and the two privacy-policy agreement fixes were found by sweeping the site source, not from a single report — happy to split them into a separate PR if you would rather keep the privacy policy change isolated.

Diff is 6 insertions / 6 deletions across 3 files, LF line endings preserved, trailing whitespace on the wrapped privacy-policy lines left exactly as it was.