### PR TITLE
docs: document username constraints (@ prefix) for LDAP, OIDC, and error codes

### DIFF
--- a/src/content/docs/integrations/errors.mdx
+++ b/src/content/docs/integrations/errors.mdx
@@ -41,6 +41,7 @@ This document describes the different errors Vikunja can return.
 | 1022      | 412              | The custom scope set by the OIDC provider is malformed. Please make sure the openid provider sets the data correctly for your scope. Check especially to have set an oidcID. |
 | 1023      | 403              | The user tried to do a user action while being authenticated as a link share.                                                                                                |
 | 1024      | 400              | The jwt claim contains invalid data.                                                                                                                                         |
+| 1039      | 400              | The username must not start with @.                                                                                                                                          |
 
 ## Validation
 

--- a/src/content/docs/setup/ldap.mdx
+++ b/src/content/docs/setup/ldap.mdx
@@ -107,6 +107,10 @@ auth:
 
 Note that Vikunja requires users to have an email address to work correctly.
 
+When creating users from LDAP:
+- **Username formatting:** spaces in the username attribute are converted to dashes (`-`), and any leading `@` symbols are trimmed (since Vikunja usernames cannot start with `@`).
+- **Email requirement:** Vikunja requires users to have an email address to work correctly.
+
 ## Avatar Synchronization
 
 Vikunja can synchronize user avatars from LDAP if your directory stores user photos. To enable this feature, configure the LDAP attribute that contains the raw image data:
@@ -149,7 +153,7 @@ When a user logs in, Vikunja will:
 
 1. Search for groups in the LDAP directory using the configured filter
 2. Create teams in Vikunja that match these groups (if they don't already exist)
-3. Add the user to the appropriate teams based on their group membership
+3. Add the user to the appropriate teams based on their group membership (matched by the user's DN, username, external subject ID, or `@`-trimmed username)
 
 You may need to adjust the `groupsyncfilter` based on your LDAP directory structure. The default filter looks for objects with class `group` or `groupOfNames`.
 

--- a/src/content/docs/setup/openid.mdx
+++ b/src/content/docs/setup/openid.mdx
@@ -337,6 +337,8 @@ If users logging in via OIDC get random usernames instead of their actual name, 
 3. `nickname` from the userinfo endpoint
 4. If none are available, a random username is generated
 
+Any leading `@` characters in the username will be automatically stripped, as Vikunja usernames cannot start with `@`.
+
 Check your provider's configuration to ensure it includes `preferred_username` in the profile scope. Some providers (like Synology SSO) do not include this claim by default.
 
 ### Users must log in before they can be assigned to tasks


### PR DESCRIPTION
Related to go-vikunja/vikunja#3816 which must be merged first.

## Summary
Documents username constraints regarding the `@` symbol prefix and character formatting:

- **LDAP (`src/content/docs/setup/ldap.mdx`)**:
  - Notes that spaces in the username attribute are replaced with hyphens (`-`) and leading `@` symbols are trimmed (since Vikunja usernames cannot start with `@`).
  - Clarifies that group sync matches members by any of DN, username, external subject ID, or `@`-trimmed username.
- **OpenID Connect (`src/content/docs/setup/openid.mdx`)**:
  - Clarifies that leading `@` characters in preferred usernames from OIDC are stripped.
- **Error Reference (`src/content/docs/integrations/errors.mdx`)**:
  - Adds error code `1039` (`The username must not start with @.`) to the User error table.