### PR TITLE
docs(filters): document @me macro in filter syntax and replace non-existent currentUser example

### DIFF
--- a/src/content/docs/integrations/filters.mdx
+++ b/src/content/docs/integrations/filters.mdx
@@ -59,6 +59,18 @@ created_by != 'service-account'
 
 Use `created_by_id` when you specifically need to compare the numeric creator ID.
 
+### Current user macro (`@me`)
+
+User-based fields (`assignees`, `created_by`) support the `@me` macro, which dynamically resolves to the authenticated user's username at runtime:
+
+```
+assignees in @me
+assignees in '@me,alice'
+created_by = @me
+```
+
+Because `@me` is resolved dynamically at search time rather than when saving the filter, saved filters and shared project views containing `@me` will automatically adapt to whoever is viewing them.
+
 ## Labels and projects by ID
 
 In the web UI, you can refer to labels and projects by name. Through the API, you must use numeric IDs:

--- a/src/content/help/filters.mdx
+++ b/src/content/help/filters.mdx
@@ -22,7 +22,7 @@ Copy any of these into a filter field to try it out:
 | `dueDate < now`                         | Overdue tasks                             |
 | `dueDate > now && dueDate < now+7d`     | Tasks due in the next 7 days              |
 | `done = false && priority >= 3`         | Undone tasks with high priority (3+)      |
-| `assignees in currentUser`              | Tasks assigned to you                     |
+| `assignees in @me`                      | Tasks assigned to you                     |
 | `createdBy = alice`                     | Tasks created by the user `alice`         |
 | `labels in urgent`                      | Tasks with the "urgent" label             |
 | `labels in urgent, logistics`           | Tasks labeled "urgent" or "logistics"     |
@@ -98,6 +98,18 @@ The filter editor offers autocomplete for field names, label names, usernames, a
 Strings with spaces or special characters must be wrapped in quotes: `"2024-03-11"`, `"waiting on others"`.
 
 Use `createdBy = alice` for one creator, or `createdBy in alice, bob` for tasks created by either user. The editor suggests matching usernames as you type.
+
+### Matching the current user (`@me`)
+
+Use the `@me` macro in user fields (like `assignees` or `createdBy`) to match the currently logged-in user dynamically:
+
+```
+assignees in @me
+assignees = @me
+createdBy = @me
+```
+
+When used in shared project views or saved filters, `@me` always evaluates to whoever is viewing the tasks. In the filter editor, this appears as **You (@me)** at the top of autocomplete suggestions.
 
 ### Operators
 


### PR DESCRIPTION
Related to go-vikunja/vikunja#3817 which needs to be merged first
Resolves go-vikunja/vikunja#3413

## Summary
Documents the `@me` macro for filter queries introduced in [go-vikunja/vikunja#3817](https://github.com/go-vikunja/vikunja/pull/3817) and corrects existing documentation inaccuracies:

- **Correction of Non-Existent `currentUser` Reference**:
  - The filters example table previously referenced `assignees in currentUser`. However, `currentUser` was never implemented in Vikunja's searcher and treated `"currentUser"` literally as a username.
  - Replaced `currentUser` with the actual implemented macro `@me` (`assignees in @me`).

- **Filter Help (`src/content/help/filters.mdx`)**:
  - Added a dedicated section explaining `@me` dynamic macro resolution in shared project views and saved filters.
  - Documented that the filter editor displays this option as **You (@me)** in autocomplete suggestions.

- **Filter API Reference (`src/content/docs/integrations/filters.mdx`)**:
  - Added a **Current user macro (`@me`)** section under `## Field names` explaining runtime evaluation of `@me` for API filter queries.